### PR TITLE
Correct issues with using system-installed xaptum-tpm

### DIFF
--- a/xaptumtpm/__init__.py
+++ b/xaptumtpm/__init__.py
@@ -12,15 +12,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License
 
-def _import_extra_search_dir():
+def _set_up_library():
     try:
         import _extra_search_dir
-
-        from xaptumtpm.wrapper import set_functions_from_library
-        set_functions_from_library(_extra_search_dir._other_dirs)
+        extra_dirs = _extra_search_dir._other_dirs
     except Exception:
-        pass
-_import_extra_search_dir()
+        extra_dirs = []
+
+    from xaptumtpm.wrapper import set_functions_from_library
+    set_functions_from_library(extra_dirs)
+
+_set_up_library()
 
 from xaptumtpm.wrapper import *
 

--- a/xaptumtpm/wrapper.py
+++ b/xaptumtpm/wrapper.py
@@ -469,7 +469,7 @@ class PosixLibraryLoader(LibraryLoader):
         try: directories.extend([dir.strip() for dir in open('/etc/ld.so.conf')])
         except IOError: pass
 
-        directories.extend(['/lib', '/usr/lib', '/lib64', '/usr/lib64'])
+        directories.extend(['/lib', '/usr/lib', '/lib64', '/usr/lib64', '/usr/local/lib', '/usr/local/lib64'])
 
         cache = {}
         lib_re = re.compile(r'lib(.*)\.s[ol]')


### PR DESCRIPTION
This includes:
- Set the imported functions, even if we're using system-installed xaptum-tpm (before, the necessary function was accidentally being called only if a local copy was being used)
- Add `/usr/local/[lib, lib64]` to the system lib search path for Posix